### PR TITLE
Added initial support for Markdown - issue-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Static Site Generator SSG
-Static Site Generator (SSG) - a tool for generating a complete HTML files from raw data like txt files. This tool was made with Python language. 
+Static Site Generator (SSG) - a tool for generating a complete HTML files from raw data like txt and md files. This tool was made with Python language. 
 
 ## Prerequisites
 - Python3
@@ -12,7 +12,13 @@ pip install beautifulsoup4
 
 ## Tool features 
 - CSS stylesheet support by specifying `--stylesheet` or `s`
-- Title parsing support. First line, indicates title followed by two blank lines. This will populate the `<title>...</title>` and add `<h1>...</h1>` to the top of the `<body>...</body>`.
+- Title parsing support for txt files. First line, indicates title followed by two blank lines. This will populate the `<title>...</title>` and add `<h1>...</h1>` to the top of the `<body>...</body>`.
+- Title parsing support for md files. Line starting with the Markup syntax \# indicates the title. This will populate the `<title>...</title>` and add `<h1>...</h1>` to the top of the `<body>...</body>`.
+- Header parsing support for md files. Lines starting with the Markup syntax \#\# or \#\#\# will be parsed with `<h2>...</h2>` and `<h3>...</h3>` tags respectively.
+- Italic syntax support for md files. Contents surrounded by Markup Syntax *\*italics\** will be parsed to html `<i>...</i>` tags.
+- Bold syntax support for md files. Contents surrounded by Markup Syntax **\*\*Bold\*\*** will be parsed to html `<b>...</b>` tags.
+- Bold and Italic syntax support for md files. Contents surrounded by Markup Syntax ***\*\*\*Bold Italcs \*\*\**** will be parsed with both italic and bold html tags.
+- Link syntax support for md files. Contents in Markup Syntax \[Link\]\(url\) will be parsed to html link tags with working links.
 - If users specifies a folder for the input, automatically generates an `index.html`, which has relative links to each of the generated files.
 
 ## Usage with shorthand flags

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ pip install beautifulsoup4
 ## Tool features 
 - CSS stylesheet support by specifying `--stylesheet` or `s`
 - Title parsing support for txt files. First line, indicates title followed by two blank lines. This will populate the `<title>...</title>` and add `<h1>...</h1>` to the top of the `<body>...</body>`.
-- Title parsing support for md files. Line starting with the Markup syntax \# indicates the title. This will populate the `<title>...</title>` and add `<h1>...</h1>` to the top of the `<body>...</body>`.
-- Header parsing support for md files. Lines starting with the Markup syntax \#\# or \#\#\# will be parsed with `<h2>...</h2>` and `<h3>...</h3>` tags respectively.
-- Italic syntax support for md files. Contents surrounded by Markup Syntax *\*italics\** will be parsed to html `<i>...</i>` tags.
-- Bold syntax support for md files. Contents surrounded by Markup Syntax **\*\*Bold\*\*** will be parsed to html `<b>...</b>` tags.
-- Bold and Italic syntax support for md files. Contents surrounded by Markup Syntax ***\*\*\*Bold Italcs \*\*\**** will be parsed with both italic and bold html tags.
-- Link syntax support for md files. Contents in Markup Syntax \[Link\]\(url\) will be parsed to html link tags with working links.
+- Title parsing support for md files. Line starting with the Markdown syntax \# indicates the title. This will populate the `<title>...</title>` and add `<h1>...</h1>` to the top of the `<body>...</body>`.
+- Header parsing support for md files. Lines starting with the Markdown syntax \#\# or \#\#\# will be parsed with `<h2>...</h2>` and `<h3>...</h3>` tags respectively.
+- Italic syntax support for md files. Contents surrounded by Markdown Syntax *\*italics\** will be parsed to html `<i>...</i>` tags.
+- Bold syntax support for md files. Contents surrounded by Markdown Syntax **\*\*Bold\*\*** will be parsed to html `<b>...</b>` tags.
+- Bold and Italic syntax support for md files. Contents surrounded by Markdown Syntax ***\*\*\*Bold Italcs \*\*\**** will be parsed with both italic and bold html tags.
+- Link syntax support for md files. Contents in Markdown Syntax \[Link\]\(url\) will be parsed to html link tags with working links.
 - If users specifies a folder for the input, automatically generates an `index.html`, which has relative links to each of the generated files.
 
 ## Usage with shorthand flags

--- a/ssg.py
+++ b/ssg.py
@@ -98,6 +98,7 @@ class TextFile:
             html_p=[]
             content_title = ""
             for content in splitted_content:
+                # regex for .md syntax
                 reg_h1 = re.compile('^# .+')
                 reg_h2 = re.compile('^## .+')
                 reg_italic = re.compile('[^\*]\*[^\*]+\*[^\*]')
@@ -119,6 +120,7 @@ class TextFile:
                         new_phrase = new_phrase.replace("**", "</b>")
                         content = content.replace(phrase, new_phrase, 1)
 
+                # Handling Headers
                 if (reg_h1.match(content)):
                     content_title = content[1:]
                     html_p.append("<h1 style='text-align: center; margin-bottom: 15px'>{title}</h1>".format(title=content_title))
@@ -254,7 +256,7 @@ def determine_path(parsed_args):
     elif (os.path.isdir(path)):
         path_obj['dir_path'] = path
         filenames = []
-        # Read only files which ends with .txt 
+        # Read only files which ends with .txt or .md
         for file in os.listdir(path):
             if (file.endswith(".txt") or file.endswith(".md")):
                 filenames.append(file)

--- a/ssg.py
+++ b/ssg.py
@@ -99,33 +99,30 @@ class TextFile:
             content_title = ""
             for content in splitted_content:
                 # regex for .md syntax
-                reg_h1 = re.compile('^# .+')
-                reg_h2 = re.compile('^## .+')
-                reg_italic = re.compile('[^\*]\*[^\*]+\*[^\*]')
-                reg_bold = re.compile('[^\*]?\*{2}[^\*]+\*{2}[^\*]?')
+                reg_h1 = re.compile('^# (.*$)')
+                reg_h2 = re.compile('^## (.*$)')
+                reg_h3 = re.compile('^### (.*$)')
+                reg_italic = '[^\*]?\*([^\*]+)\*[^\*]?'
+                reg_bold = '[^\*]?\*{2}([^\*]+)\*{2}[^\*]?'
+                reg_link = '\[(.+)\]\((.+)\)'
 
-                # Handling italics
-                result_italic = reg_italic.findall(content)
-                if (result_italic):
-                    for phrase in result_italic:
-                        new_phrase = phrase.replace("*", "<i>", 1)
-                        new_phrase = new_phrase.replace("*", "</i>")
-                        content = content.replace(phrase, new_phrase, 1)
+                # Handling italics and bold in italics
+                content = re.sub(reg_italic, r' <i>\1</i> ', re.sub(reg_bold, r' <b>\1</b> ', content))
 
-                # Handling bold
-                result_bold = reg_bold.findall(content)
-                if (result_bold):
-                    for phrase in result_bold:
-                        new_phrase = phrase.replace("**", "<b>", 1)
-                        new_phrase = new_phrase.replace("**", "</b>")
-                        content = content.replace(phrase, new_phrase, 1)
+                # Handling bold and italics in bold
+                content = re.sub(reg_bold, r' <b>\1</b> ', re.sub(reg_italic, r' <i>\1</i> ', content))
 
-                # Handling Headers
+                # Handling links
+                content = re.sub(reg_link, r'<a href="\2">\1</a>', content)
+
+                # Handling Headers and paragraphs
                 if (reg_h1.match(content)):
                     content_title = content[1:]
                     html_p.append("<h1 style='text-align: center; margin-bottom: 15px'>{title}</h1>".format(title=content_title))
                 elif (reg_h2.match(content)):
                     html_p.append("<h2 style='text-align: center; margin-bottom: 15px'>{subtitle}</h2>".format(subtitle=content[2:]))
+                elif (reg_h3.match(content)):
+                    html_p.append("<h3 style='text-align: center; margin-bottom: 15px'>{subtitle}</h3>".format(subtitle=content[3:]))
                 else:
                     # Handle encoding for windows
                     if platform.system() == "Windows":
@@ -133,6 +130,7 @@ class TextFile:
                     # Handle encoding for Mac and other platforms
                     else:
                         html_p.append("<p>{content}</p>".format(content=content.encode('utf8')))
+                        
             processed_content = {
                 "title": content_title,
                 "content": html_p,

--- a/ssg.py
+++ b/ssg.py
@@ -125,7 +125,7 @@ class TextFile:
                     content_title = content[1:]
                     html_p.append("<h1 style='text-align: center; margin-bottom: 15px'>{title}</h1>".format(title=content_title))
                 elif (reg_h2.match(content)):
-                    html_p.append("<h2 style='text-align: center; margin-bottom: 15px'>{subtitle}</h1>".format(subtitle=content[2:]))
+                    html_p.append("<h2 style='text-align: center; margin-bottom: 15px'>{subtitle}</h2>".format(subtitle=content[2:]))
                 else:
                     # Handle encoding for windows
                     if platform.system() == "Windows":

--- a/ssg.py
+++ b/ssg.py
@@ -99,12 +99,17 @@ class TextFile:
             content_title = ""
             for content in splitted_content:
                 # regex for .md syntax
-                reg_h1 = re.compile('^# (.*$)')
-                reg_h2 = re.compile('^## (.*$)')
-                reg_h3 = re.compile('^### (.*$)')
+                reg_h1 = re.compile('[^#]*# (.*$)')
+                reg_h2 = '(^[^#])*## ([^#]+)*(.*$)'
+                reg_h3 = '(^[^#])*### ([^#]+)*(.*$)'
                 reg_italic = '[^\*]?\*([^\*]+)\*[^\*]?'
                 reg_bold = '[^\*]?\*{2}([^\*]+)\*{2}[^\*]?'
                 reg_link = '\[(.+)\]\((.+)\)'
+                reg_p = '(^[^#]*$)'
+                reg_newline = '\n'
+
+                # Handling newline
+                content = re.sub(reg_newline, '<br>', content)
 
                 # Handling italics and bold in italics
                 content = re.sub(reg_italic, r' <i>\1</i> ', re.sub(reg_bold, r' <b>\1</b> ', content))
@@ -116,20 +121,20 @@ class TextFile:
                 content = re.sub(reg_link, r'<a href="\2">\1</a>', content)
 
                 # Handling Headers and paragraphs
+                content = re.sub(reg_p, r'<p>\1</p>', content)
+                content = re.sub(reg_h2, r"\1<h2 style='text-align: center; margin-bottom: 15px'>\2</h2>\3", content)
+                content = re.sub(reg_h3, r"\1<h3 style='text-align: center; margin-bottom: 15px'>\2</h3>\3", content)
+
                 if (reg_h1.match(content)):
                     content_title = content[1:]
                     html_p.append("<h1 style='text-align: center; margin-bottom: 15px'>{title}</h1>".format(title=content_title))
-                elif (reg_h2.match(content)):
-                    html_p.append("<h2 style='text-align: center; margin-bottom: 15px'>{subtitle}</h2>".format(subtitle=content[2:]))
-                elif (reg_h3.match(content)):
-                    html_p.append("<h3 style='text-align: center; margin-bottom: 15px'>{subtitle}</h3>".format(subtitle=content[3:]))
-                else:
+                else :
                     # Handle encoding for windows
                     if platform.system() == "Windows":
-                        html_p.append("<p>{content}</p>".format(content=content.encode('utf8').decode('utf8')))
+                        html_p.append("{content}".format(content=content.encode('utf8').decode('utf8')))
                     # Handle encoding for Mac and other platforms
                     else:
-                        html_p.append("<p>{content}</p>".format(content=content.encode('utf8')))
+                        html_p.append("{content}".format(content=content.encode('utf8')))
                         
             processed_content = {
                 "title": content_title,


### PR DESCRIPTION
Fixes #8 

The original tool had no support for Markdown files. I've added initial support for Markdown files with the use of regex.

`import re` is needed to use regex. 

The tool will now also read files that ends with ".md"

In TextFile.process_file(), the code will process between ".txt" and ".md" files.
The process for ".txt" files have not been changed.
For ".md" files, it will process markdown syntax features for
 - Italics - will be generated surrounded by \<i\>...\</i\> tag
 - Bold - will be generated surrounded by \<b\>...\</b\> tag
 - Heading 1 - Context in Heading 1 for any ".md" file is treated as the title. Will be generated surrounded by \<h1\>...\</h1\> tag
 - Heading 2 - Will be generated surrounded by \<h2\>... \</h2\> tag

I've created regex patterns for each individual syntax for easier implementation and editing.

To handle bold and italics, I've used the findall() function in python to find all instances where the contents matches the regex in a single paragraph. Then I've replaced all matching instances from their Markdown syntax to having the corresponding html tag. 

I've noticed that html italic and bold tags will cause the generated files to create new indented code blocks in html.
For example
```
*I* am afraid, Watson, that I shall have to go,” said Holmes, as we
sat *down* together to our breakfast **one** morning.
```
in .md files will generate in html as
```
  <p>
   <i>
    I
   </i>
   am afraid, Watson, that I shall have to go,” said Holmes, as we
sat
   <i>
    down
   </i>
   together to our breakfast
   <b>
    one
   </b>
   morning.
  </p>
```

The webpage will generate looking fine. But I'm still trying to figure out if this might be the cause of BeautifulSoup parsing, or something else.

Please review and provide feedback at your latest convenience. Thanks!


